### PR TITLE
Align cache filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A command-line tool, written in Rust and licensed under the GPLv3, to fetch, dis
 
 * **License Discovery & Caching:**
   * Fetches license templates and metadata (`rules.yml`, `fields.yml`) from `choosealicense.com`.
-  * Maintains an efficient local JSON cache (`getlicense_cache.json`).
+  * Maintains an efficient local JSON cache (`license_cache_rs.json`).
   * Automatically updates cache based on remote file changes (Git SHAs).
   * Pre-parses and caches license details (placeholders, rules, descriptions) for faster operations.
 * **Listing & Comparison:**

--- a/get.py
+++ b/get.py
@@ -28,7 +28,7 @@ REPO: str = "choosealicense.com"
 BRANCH: str = "gh-pages"
 LICENSES_PATH: str = "_licenses"
 DATA_PATH: str = "_data"
-CACHE_FILENAME: str = "license_cache.json"
+CACHE_FILENAME: str = "license_cache_rs.json"
 USER_PLACEHOLDERS_CACHE_KEY: str = "user_placeholders"
 
 


### PR DESCRIPTION
## Summary
- update references to `license_cache_rs.json`
- align Python cache filename with Rust constants

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt missing)*
- `cargo clippy -- -D warnings` *(fails: clippy missing)*
- `cargo test` *(fails: could not download crates)*