### PR TITLE
Use atomic globals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ indicatif = "0.17"
 colored = "2"
 dirs = "5"
 unicode-ellipsis = "0.3.0"
+once_cell = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/actions/compare.rs
+++ b/src/actions/compare.rs
@@ -1,28 +1,33 @@
-use crate::models::{Cache, LicenseEntry, RulesDataContent};
 use crate::display;
 use crate::error::AppError;
+use crate::models::{Cache, LicenseEntry, RulesDataContent};
+use std::sync::atomic::Ordering;
 
 pub async fn CompareLicenses(
     cache: &Cache,
     requestedIds: Option<Vec<String>>,
 ) -> Result<(), AppError> {
-
-    if unsafe { crate::VERBOSE } {
-        eprintln!("[Action] Comparing licenses. Requested IDs: {:?}", requestedIds);
+    if crate::VERBOSE.load(Ordering::SeqCst) {
+        eprintln!(
+            "[Action] Comparing licenses. Requested IDs: {:?}",
+            requestedIds
+        );
     }
 
     let targetKeysLower: Vec<String> = match requestedIds {
         Some(ids) if !ids.is_empty() => ids
             .into_iter()
-            .filter_map(|idStr| { // idStr is correct
+            .filter_map(|idStr| {
+                // idStr is correct
                 let idLower = idStr.to_lowercase();
 
                 if cache.licenses.contains_key(&idLower) {
                     Some(idLower)
-                }
-
-                else {
-                    eprintln!("[Action] Warning: License '{}' for comparison not found. Skipping.", idStr);
+                } else {
+                    eprintln!(
+                        "[Action] Warning: License '{}' for comparison not found. Skipping.",
+                        idStr
+                    );
                     None
                 }
             })
@@ -43,20 +48,22 @@ pub async fn CompareLicenses(
     let mut licensesToCompare: Vec<&LicenseEntry> = Vec::new();
 
     for key in &targetKeysLower {
-
         if let Some(entry) = cache.licenses.get(key) {
             licensesToCompare.push(entry);
         }
-
     }
 
     if licensesToCompare.len() < 2 {
-        println!("After filtering, only {} licenses are available for comparison. Need at least two.", licensesToCompare.len());
+        println!(
+            "After filtering, only {} licenses are available for comparison. Need at least two.",
+            licensesToCompare.len()
+        );
 
         return Ok(());
     }
 
-    let rulesDataContent: Option<RulesDataContent> = cache.dataFiles // dataFiles is correct
+    let rulesDataContent: Option<RulesDataContent> = cache
+        .dataFiles // dataFiles is correct
         .get(crate::constants::RULES_YML_KEY)
         .and_then(|entry| serde_yaml::from_value(entry.content.clone()).ok());
 

--- a/src/actions/fill.rs
+++ b/src/actions/fill.rs
@@ -2,35 +2,35 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::models::Cache;
-use crate::cli::{LicenseFillArgs, Cli as FullCliArgs};
-use crate::parser;
-use crate::display;
-use crate::error::{AppError, ActionError};
+use crate::cli::{Cli as FullCliArgs, LicenseFillArgs};
 use crate::constants::{CACHABLE_PLACEHOLDER_KEYS, CLI_ARG_TO_CACHE_KEY_TUPLES};
+use crate::display;
+use crate::error::{ActionError, AppError};
+use crate::models::Cache;
+use crate::parser;
 use chrono::Datelike;
 use colored::*;
-
+use std::sync::atomic::Ordering;
 
 pub async fn FillLicenseTemplateAction(
     cache: &mut Cache,
     args: &LicenseFillArgs,
     cliAllArgs: &FullCliArgs,
 ) -> Result<bool, AppError> {
-
     let spdxIdLower = args.licenseId.to_lowercase();
 
-
-    if unsafe { crate::VERBOSE } {
+    if crate::VERBOSE.load(Ordering::SeqCst) {
         eprintln!("[Action] Filling license template for: {}", spdxIdLower);
     }
 
-    let licenseEntry = cache.licenses.get(&spdxIdLower)
-        .ok_or_else(|| AppError::ActionErrorVariant(ActionError::LicenseNotFound(spdxIdLower.clone())))?;
+    let licenseEntry = cache.licenses.get(&spdxIdLower).ok_or_else(|| {
+        AppError::ActionErrorVariant(ActionError::LicenseNotFound(spdxIdLower.clone()))
+    })?;
 
     let templateBody = &licenseEntry.fileContentCached;
 
-    println!("\nUsing license: {} ({})",
+    println!(
+        "\nUsing license: {} ({})",
         licenseEntry.title.cyan().bold(),
         licenseEntry.spdxId.cyan()
     );
@@ -39,42 +39,31 @@ pub async fn FillLicenseTemplateAction(
     let mut userProvidedForCaching: HashMap<String, String> = HashMap::new();
 
     // Collect CLI args for cachable placeholders
-    let cliArgToCacheKeyMap: HashMap<&str, &str> = CLI_ARG_TO_CACHE_KEY_TUPLES.iter().cloned().collect();
-
+    let cliArgToCacheKeyMap: HashMap<&str, &str> =
+        CLI_ARG_TO_CACHE_KEY_TUPLES.iter().cloned().collect();
 
     if let Some(name) = &args.fullname {
-
         if let Some(key) = cliArgToCacheKeyMap.get("fullname") {
-             userProvidedForCaching.insert(key.to_string(), name.clone());
+            userProvidedForCaching.insert(key.to_string(), name.clone());
         }
-
     }
-
 
     if let Some(proj) = &args.project {
-
-         if let Some(key) = cliArgToCacheKeyMap.get("project") {
+        if let Some(key) = cliArgToCacheKeyMap.get("project") {
             userProvidedForCaching.insert(key.to_string(), proj.clone());
         }
-
     }
 
-
     if let Some(mail) = &args.email {
-
         if let Some(key) = cliArgToCacheKeyMap.get("email") {
             userProvidedForCaching.insert(key.to_string(), mail.clone());
         }
-
     }
 
-
     if let Some(url) = &args.projecturl {
-
         if let Some(key) = cliArgToCacheKeyMap.get("projecturl") {
             userProvidedForCaching.insert(key.to_string(), url.clone());
         }
-
     }
 
     // --- Determine Final Replacements for Template Filling ---
@@ -82,12 +71,12 @@ pub async fn FillLicenseTemplateAction(
 
     // 1. Start with cached preferences (non-year)
 
-    for keyStr in CACHABLE_PLACEHOLDER_KEYS.iter() { // CACHABLE_PLACEHOLDER_KEYS is an array of &str
+    for keyStr in CACHABLE_PLACEHOLDER_KEYS.iter() {
+        // CACHABLE_PLACEHOLDER_KEYS is an array of &str
 
         if let Some(val) = cachedPlaceholdersAtStart.get(*keyStr) {
             finalTemplateReplacements.insert(keyStr.to_string(), val.clone());
         }
-
     }
 
     // 2. Override with current CLI arguments (non-year)
@@ -106,34 +95,37 @@ pub async fn FillLicenseTemplateAction(
     let filledLicenseBody = parser::FillLicenseTemplateBody(
         templateBody,
         &finalTemplateReplacements,
-        &licenseEntry.placeholdersInBody
+        &licenseEntry.placeholdersInBody,
     );
 
-    let outputPath = args.output.clone().unwrap_or_else(|| PathBuf::from("LICENSE"));
-
+    let outputPath = args
+        .output
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("LICENSE"));
 
     if let Some(parent) = outputPath.parent() {
-        fs::create_dir_all(parent).map_err(|e| AppError::ActionErrorVariant(ActionError::FileOperation(e, parent.to_path_buf())))?;
+        fs::create_dir_all(parent).map_err(|e| {
+            AppError::ActionErrorVariant(ActionError::FileOperation(e, parent.to_path_buf()))
+        })?;
     }
 
-    fs::write(&outputPath, filledLicenseBody.clone() + "\n")
-        .map_err(|e| AppError::ActionErrorVariant(ActionError::FileOperation(e, outputPath.clone())))?;
+    fs::write(&outputPath, filledLicenseBody.clone() + "\n").map_err(|e| {
+        AppError::ActionErrorVariant(ActionError::FileOperation(e, outputPath.clone()))
+    })?;
 
     let mut placeholderCacheModified = false;
-
 
     if !userProvidedForCaching.is_empty() {
         cache.userPlaceholders.extend(userProvidedForCaching);
         placeholderCacheModified = true;
 
-        if unsafe { crate::VERBOSE } {
+        if crate::VERBOSE.load(Ordering::SeqCst) {
             eprintln!("[Action] Updated saved placeholder preferences with current CLI arguments.");
         }
-
     }
 
     // Pass the whole cache for access to fields.yml etc. for summary display
-    // Pass all CLI args for context for the summary display    
+    // Pass all CLI args for context for the summary display
     display::DisplayLicenseSummaryAfterWrite(
         &licenseEntry,
         &cache,
@@ -143,7 +135,6 @@ pub async fn FillLicenseTemplateAction(
         &filledLicenseBody,
         cliAllArgs,
     );
-
 
     Ok(placeholderCacheModified)
 }

--- a/src/actions/find.rs
+++ b/src/actions/find.rs
@@ -1,7 +1,8 @@
-use std::collections::HashSet;
-use crate::models::{Cache, LicenseEntry, RulesDataContent};
 use crate::display;
-use crate::error::{AppError, ActionError};
+use crate::error::{ActionError, AppError};
+use crate::models::{Cache, LicenseEntry, RulesDataContent};
+use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 
 pub async fn FindMatchingLicenses(
     cache: &Cache,
@@ -11,65 +12,79 @@ pub async fn FindMatchingLicenses(
     let requireTags = requireTagsOpt.unwrap_or_default();
     let disallowTags = disallowTagsOpt.unwrap_or_default();
 
-
-    if unsafe { crate::VERBOSE } {
-        eprintln!("[Action] Finding licenses. Require: {:?}, Disallow: {:?}", requireTags, disallowTags);
+    if crate::VERBOSE.load(Ordering::SeqCst) {
+        eprintln!(
+            "[Action] Finding licenses. Require: {:?}, Disallow: {:?}",
+            requireTags, disallowTags
+        );
     }
-
 
     if requireTags.is_empty() && disallowTags.is_empty() {
-
         return Err(AppError::ActionErrorVariant(ActionError::InvalidInput(
-            "Please provide at least one --require or --disallow tag for finding licenses.".to_string(),
+            "Please provide at least one --require or --disallow tag for finding licenses."
+                .to_string(),
         )));
-
     }
 
-
-    let rulesDataContent: RulesDataContent = cache.dataFiles // dataFiles is correct
+    let rulesDataContent: RulesDataContent = cache
+        .dataFiles // dataFiles is correct
         .get(crate::constants::RULES_YML_KEY)
         .and_then(|entry| serde_yaml::from_value(entry.content.clone()).ok())
-        .ok_or_else(|| AppError::ActionErrorVariant(ActionError::MissingData( // Corrected this line based on other similar changes
-            "rules.yml data not found in cache. Cannot validate find tags.".to_string()
-        )))?;
+        .ok_or_else(|| {
+            AppError::ActionErrorVariant(ActionError::MissingData(
+                // Corrected this line based on other similar changes
+                "rules.yml data not found in cache. Cannot validate find tags.".to_string(),
+            ))
+        })?;
 
     let mut allValidTags = HashSet::new();
 
-
-    for ruleList in [&rulesDataContent.permissions, &rulesDataContent.conditions, &rulesDataContent.limitations].iter() {
-
+    for ruleList in [
+        &rulesDataContent.permissions,
+        &rulesDataContent.conditions,
+        &rulesDataContent.limitations,
+    ]
+    .iter()
+    {
         for ruleSource in *ruleList {
             allValidTags.insert(ruleSource.tag.clone());
         }
-
     }
 
-
-    let invalidRequire: Vec<_> = requireTags.iter().filter(|t| !allValidTags.contains(*t)).cloned().collect();
-    let invalidDisallow: Vec<_> = disallowTags.iter().filter(|t| !allValidTags.contains(*t)).cloned().collect();
-
+    let invalidRequire: Vec<_> = requireTags
+        .iter()
+        .filter(|t| !allValidTags.contains(*t))
+        .cloned()
+        .collect();
+    let invalidDisallow: Vec<_> = disallowTags
+        .iter()
+        .filter(|t| !allValidTags.contains(*t))
+        .cloned()
+        .collect();
 
     if !invalidRequire.is_empty() || !invalidDisallow.is_empty() {
         let mut errMsg = "Invalid rule tags provided:".to_string();
 
-
         if !invalidRequire.is_empty() {
-            errMsg.push_str(&format!("\n  Invalid --require tags: {}", invalidRequire.join(", ")));
+            errMsg.push_str(&format!(
+                "\n  Invalid --require tags: {}",
+                invalidRequire.join(", ")
+            ));
         }
-
 
         if !invalidDisallow.is_empty() {
-            errMsg.push_str(&format!("\n  Invalid --disallow tags: {}", invalidDisallow.join(", ")));
+            errMsg.push_str(&format!(
+                "\n  Invalid --disallow tags: {}",
+                invalidDisallow.join(", ")
+            ));
         }
 
-
-        return Err(AppError::ActionErrorVariant(ActionError::InvalidInput(errMsg)));
-
+        return Err(AppError::ActionErrorVariant(ActionError::InvalidInput(
+            errMsg,
+        )));
     }
 
-
     let mut matches: Vec<&LicenseEntry> = Vec::new();
-
 
     for licenseEntry in cache.licenses.values() {
         // The raw tags are directly available in LicenseEntry
@@ -81,11 +96,9 @@ pub async fn FindMatchingLicenses(
         let meetsRequire = requireTags.iter().all(|tag| licenseRules.contains(tag));
         let meetsDisallow = !disallowTags.iter().any(|tag| licenseRules.contains(tag));
 
-
         if meetsRequire && meetsDisallow {
             matches.push(licenseEntry);
         }
-
     }
 
     // Sort matches by SPDX ID for consistent output

--- a/src/actions/info.rs
+++ b/src/actions/info.rs
@@ -1,20 +1,19 @@
-use crate::models::{Cache, FieldsDataContent};
 use crate::display;
-use crate::error::{AppError, ActionError};
+use crate::error::{ActionError, AppError};
+use crate::models::{Cache, FieldsDataContent};
+use std::sync::atomic::Ordering;
 
-pub async fn DisplayLicenseInfo(
-    cache: &Cache,
-    spdxIdStr: &str,
-) -> Result<(), AppError> {
+pub async fn DisplayLicenseInfo(cache: &Cache, spdxIdStr: &str) -> Result<(), AppError> {
     let spdxIdLower = spdxIdStr.to_lowercase();
 
-    if unsafe { crate::VERBOSE } {
+    if crate::VERBOSE.load(Ordering::SeqCst) {
         eprintln!("[Action] Displaying info for license: {}", spdxIdLower);
     }
 
     match cache.licenses.get(&spdxIdLower) {
         Some(licenseEntry) => {
-            let fieldsDataContent: Option<FieldsDataContent> = cache.dataFiles // dataFiles is correct
+            let fieldsDataContent: Option<FieldsDataContent> = cache
+                .dataFiles // dataFiles is correct
                 .get(crate::constants::FIELDS_YML_KEY)
                 .and_then(|entry| serde_yaml::from_value(entry.content.clone()).ok());
 
@@ -22,35 +21,32 @@ pub async fn DisplayLicenseInfo(
 
             Ok(())
         }
-        None =>
-            Err(AppError::ActionErrorVariant(ActionError::LicenseNotFound(spdxIdLower)))
+        None => Err(AppError::ActionErrorVariant(ActionError::LicenseNotFound(
+            spdxIdLower,
+        ))),
     }
 }
 
-pub async fn ShowPlaceholdersForLicense(
-    cache: &Cache,
-    spdxIdStr: &str,
-) -> Result<(), AppError> {
+pub async fn ShowPlaceholdersForLicense(cache: &Cache, spdxIdStr: &str) -> Result<(), AppError> {
     let spdxIdLower = spdxIdStr.to_lowercase();
 
-    if unsafe { crate::VERBOSE } {
+    if crate::VERBOSE.load(Ordering::SeqCst) {
         eprintln!("[Action] Showing placeholders for license: {}", spdxIdLower);
     }
 
     match cache.licenses.get(&spdxIdLower) {
         Some(licenseEntry) => {
-            let fieldsDataContent: Option<FieldsDataContent> = cache.dataFiles // dataFiles is correct
+            let fieldsDataContent: Option<FieldsDataContent> = cache
+                .dataFiles // dataFiles is correct
                 .get(crate::constants::FIELDS_YML_KEY)
                 .and_then(|entry| serde_yaml::from_value(entry.content.clone()).ok());
 
-            display::PrintPlaceholderList(
-                &licenseEntry,
-                &fieldsDataContent,
-            );
+            display::PrintPlaceholderList(&licenseEntry, &fieldsDataContent);
 
             Ok(())
         }
-        None =>
-            Err(AppError::ActionErrorVariant(ActionError::LicenseNotFound(spdxIdLower)))
+        None => Err(AppError::ActionErrorVariant(ActionError::LicenseNotFound(
+            spdxIdLower,
+        ))),
     }
 }

--- a/src/actions/placeholder_management.rs
+++ b/src/actions/placeholder_management.rs
@@ -1,19 +1,18 @@
-use colored::*;
-use crate::models::Cache;
 use crate::error::AppError;
+use crate::models::Cache;
+use colored::*;
+use std::sync::atomic::Ordering;
 
-pub async fn SetPlaceholder(
-    cache: &mut Cache,
-    key: &str,
-    value: &str,
-) -> Result<(), AppError> {
-
-    if unsafe { crate::VERBOSE } {
+pub async fn SetPlaceholder(cache: &mut Cache, key: &str, value: &str) -> Result<(), AppError> {
+    if crate::VERBOSE.load(Ordering::SeqCst) {
         eprintln!("[Action] Setting placeholder: {} = {}", key, value);
     }
 
-    cache.userPlaceholders.insert(key.to_string(), value.to_string());
-    println!("Placeholder '{}' set to '{}' in saved preferences.",
+    cache
+        .userPlaceholders
+        .insert(key.to_string(), value.to_string());
+    println!(
+        "Placeholder '{}' set to '{}' in saved preferences.",
         key.green(),
         value.cyan()
     );
@@ -21,15 +20,10 @@ pub async fn SetPlaceholder(
     Ok(())
 }
 
-pub async fn GetPlaceholder(
-    cache: &Cache,
-    keyOpt: Option<&str>,
-) -> Result<(), AppError> {
-
-    if unsafe { crate::VERBOSE } {
+pub async fn GetPlaceholder(cache: &Cache, keyOpt: Option<&str>) -> Result<(), AppError> {
+    if crate::VERBOSE.load(Ordering::SeqCst) {
         eprintln!("[Action] Getting placeholder(s). Key: {:?}", keyOpt);
     }
-
 
     if cache.userPlaceholders.is_empty() {
         println!("No saved placeholder preferences found.");
@@ -37,10 +31,8 @@ pub async fn GetPlaceholder(
         return Ok(());
     }
 
-
     match keyOpt {
         Some(key) => {
-
             if let Some(value) = cache.userPlaceholders.get(key) {
                 println!("{}: {}", key.green(), value.cyan());
             } else {
@@ -55,7 +47,7 @@ pub async fn GetPlaceholder(
         None => {
             println!("{}", "Saved Placeholder Preferences:".bold());
             let mut sortedPlaceholders: Vec<_> = cache.userPlaceholders.iter().collect();
-            sortedPlaceholders.sort_by_key(|(k,_)| *k);
+            sortedPlaceholders.sort_by_key(|(k, _)| *k);
 
             for (k, v) in sortedPlaceholders {
                 println!("  {}: {}", k.green(), v.cyan());
@@ -70,27 +62,24 @@ pub async fn ClearPlaceholders(
     cache: &mut Cache,
     keysOpt: Option<Vec<String>>,
 ) -> Result<(), AppError> {
-
-    if unsafe { crate::VERBOSE } {
+    if crate::VERBOSE.load(Ordering::SeqCst) {
         eprintln!("[Action] Clearing placeholder(s). Keys: {:?}", keysOpt);
     }
 
-
     match keysOpt {
         Some(keysToClear) if !keysToClear.is_empty() => {
-
             for key in keysToClear {
-
                 if cache.userPlaceholders.remove(&key).is_some() {
                     println!("Cleared saved preference for '{}'.", key.green());
                 } else {
-                    println!("No saved preference found for key '{}' to clear.", key.yellow());
+                    println!(
+                        "No saved preference found for key '{}' to clear.",
+                        key.yellow()
+                    );
                 }
             }
-
         }
         _ => {
-
             if cache.userPlaceholders.is_empty() {
                 println!("No saved placeholder preferences to clear.");
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,42 +1,40 @@
 #![allow(non_snake_case)]
 
 use clap::Parser;
+use once_cell::sync::Lazy;
 use std::io;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio;
 
 mod cli;
 // For Cache, etc. if used directly in main
-mod models;
-mod cache;
 mod actions;
-mod error;
+mod cache;
 mod constants;
+mod error;
+mod models;
 // For potential direct calls or if actions re-export display functions
+mod api;
 mod display;
 mod parser;
-mod api;
 
 use cli::{Cli, Commands};
-use error::AppError;
 use constants::DEFAULT_CACHE_FILENAME;
+use error::AppError;
 
 // Global flag to indicate if cache was modified by an action (e.g. placeholder management)
 // This helps decide if SaveCache needs to be called.
-pub static mut VERBOSE: bool = false;
-static mut CACHE_MODIFIED_BY_ACTION: bool = false;
-
+pub static VERBOSE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+static CACHE_MODIFIED_BY_ACTION: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 
 #[tokio::main]
 async fn main() -> Result<(), AppError> {
     let cli_args = Cli::parse();
 
-    // SAFETY: Single-threaded access at program start.
-    unsafe {
-        VERBOSE = cli_args.verbose;
-    }
+    VERBOSE.store(cli_args.verbose, Ordering::SeqCst);
 
-    if unsafe { VERBOSE } {
+    if VERBOSE.load(Ordering::SeqCst) {
         eprintln!("Verbose mode enabled.");
     }
 
@@ -46,7 +44,6 @@ async fn main() -> Result<(), AppError> {
         clap_complete::generate(shell, &mut cmd, app_name, &mut io::stdout());
 
         return Ok(());
-
     }
 
     let cache_file_path = cli_args.cacheFile.clone().unwrap_or_else(|| {
@@ -55,7 +52,7 @@ async fn main() -> Result<(), AppError> {
         home_dir.join(DEFAULT_CACHE_FILENAME)
     });
 
-    if unsafe { crate::VERBOSE } {
+    if VERBOSE.load(Ordering::SeqCst) {
         eprintln!("Using cache file: {:?}", cache_file_path);
     }
 
@@ -85,31 +82,29 @@ async fn main() -> Result<(), AppError> {
         }
         Some(Commands::License(ref args)) => {
             // The fill action might modify the cache (user_placeholders)
-            let modified_placeholder_cache = actions::fill::FillLicenseTemplateAction(
-                &mut cache_data,
-                args,
-                &cli_args,
-            )
-            .await?;
+            let modified_placeholder_cache =
+                actions::fill::FillLicenseTemplateAction(&mut cache_data, args, &cli_args).await?;
 
             if modified_placeholder_cache {
-                // SAFETY: Single-threaded logical section.
-                unsafe { CACHE_MODIFIED_BY_ACTION = true; }
+                CACHE_MODIFIED_BY_ACTION.store(true, Ordering::SeqCst);
             }
-
         }
         Some(Commands::SetPlaceholder(args)) => {
-            actions::placeholder_management::SetPlaceholder(&mut cache_data, &args.key, &args.value).await?;
-            // SAFETY: Single-threaded logical section.
-            unsafe { CACHE_MODIFIED_BY_ACTION = true; }
+            actions::placeholder_management::SetPlaceholder(
+                &mut cache_data,
+                &args.key,
+                &args.value,
+            )
+            .await?;
+            CACHE_MODIFIED_BY_ACTION.store(true, Ordering::SeqCst);
         }
         Some(Commands::GetPlaceholder(args)) => {
-            actions::placeholder_management::GetPlaceholder(&cache_data, args.key.as_deref()).await?;
+            actions::placeholder_management::GetPlaceholder(&cache_data, args.key.as_deref())
+                .await?;
         }
         Some(Commands::ClearPlaceholders(args)) => {
             actions::placeholder_management::ClearPlaceholders(&mut cache_data, args.keys).await?;
-            // SAFETY: Single-threaded logical section.
-            unsafe { CACHE_MODIFIED_BY_ACTION = true; }
+            CACHE_MODIFIED_BY_ACTION.store(true, Ordering::SeqCst);
         }
         None => {
             action_was_handled = false;
@@ -126,21 +121,16 @@ async fn main() -> Result<(), AppError> {
         return Ok(());
     }
 
-    if cache_updated_by_fetch || unsafe { CACHE_MODIFIED_BY_ACTION } {
-
-        if unsafe { crate::VERBOSE } {
+    if cache_updated_by_fetch || CACHE_MODIFIED_BY_ACTION.load(Ordering::SeqCst) {
+        if VERBOSE.load(Ordering::SeqCst) {
             eprintln!("Saving cache changes to {:?}...", cache_file_path);
         }
 
         cache::SaveCache(&cache_file_path, &cache_data).await?;
-
-    }
-
-    else {
-        if unsafe { crate::VERBOSE } {
+    } else {
+        if VERBOSE.load(Ordering::SeqCst) {
             eprintln!("No changes to save to cache file.");
         }
-
     }
 
     return Ok(());


### PR DESCRIPTION
## Summary
- replace `static mut` globals with atomic booleans
- update all reads/writes to use atomic operations
- remove `unsafe` usages for verbose flag and cache update flag

## Testing
- `cargo clippy` *(fails: could not download crates)*