### PR TITLE
Fix clippy needless borrow errors

### DIFF
--- a/src/actions/fill.rs
+++ b/src/actions/fill.rs
@@ -127,8 +127,8 @@ pub async fn FillLicenseTemplateAction(
     // Pass the whole cache for access to fields.yml etc. for summary display
     // Pass all CLI args for context for the summary display
     display::DisplayLicenseSummaryAfterWrite(
-        &licenseEntry,
-        &cache,
+        licenseEntry,
+        cache,
         &outputPath,
         &userProvidedForFillingSummary,
         &cachedPlaceholdersAtStart,

--- a/src/actions/info.rs
+++ b/src/actions/info.rs
@@ -17,7 +17,7 @@ pub async fn DisplayLicenseInfo(cache: &Cache, spdxIdStr: &str) -> Result<(), Ap
                 .get(crate::constants::FIELDS_YML_KEY)
                 .and_then(|entry| serde_yaml::from_value(entry.content.clone()).ok());
 
-            display::PrintLicenseInfoPanel(&licenseEntry, &fieldsDataContent);
+            display::PrintLicenseInfoPanel(licenseEntry, &fieldsDataContent);
 
             Ok(())
         }
@@ -41,7 +41,7 @@ pub async fn ShowPlaceholdersForLicense(cache: &Cache, spdxIdStr: &str) -> Resul
                 .get(crate::constants::FIELDS_YML_KEY)
                 .and_then(|entry| serde_yaml::from_value(entry.content.clone()).ok());
 
-            display::PrintPlaceholderList(&licenseEntry, &fieldsDataContent);
+            display::PrintPlaceholderList(licenseEntry, &fieldsDataContent);
 
             Ok(())
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,8 +21,6 @@ pub enum AppError {
     #[error("I/O error for path '{1}': {0}")]
     Io(#[source] std::io::Error, PathBuf), // Or IoError if Io is a type name
 
-    #[error("No action specified by the user.")]
-    NoActionSpecified,
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
## Summary
- clean up references passed to summary display
- remove explicit borrowing when printing license info
- drop unused `NoActionSpecified` error variant

## Testing
- `cargo check`
- `cargo clippy`
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*